### PR TITLE
fix: building for debug mode

### DIFF
--- a/API/hermes/hermes_napi.cpp
+++ b/API/hermes/hermes_napi.cpp
@@ -463,7 +463,7 @@ class NapiStableAddressStack final {
  private:
   // The size of 64 entries per chunk is arbitrary at this point.
   // It can be adjusted depending on perf data.
-  static const size_t ChunkSize = 64;
+  static const constexpr size_t ChunkSize = 64;
 
   llvh::SmallVector<std::unique_ptr<T[]>, ChunkSize> storage_;
   size_t size_{0};


### PR DESCRIPTION
Fixes the issue I got building for debug mode (screenshotted below) by resolving a difference between Clang compiler vs MSVC.

The issue:

![image](https://github.com/DjDeveloperr/hermes-windows/assets/14055146/062da26c-965e-4b90-afe6-d90b518a9b38)
